### PR TITLE
Update the updater to expect new names for the updater .jar files

### DIFF
--- a/src/main/java/net/imagej/updater/CommandLine.java
+++ b/src/main/java/net/imagej/updater/CommandLine.java
@@ -807,7 +807,7 @@ public class CommandLine {
 				&& files.util.isLauncher(file.filename)) {
 			file.executable = true;
 			file.addPlatform(UpdaterUtil.platformForLauncher(file.filename));
-			for (final String fileName : new String[] { "jars/ij-launcher.jar" }) {
+			for (final String fileName : new String[] { "jars/imagej-launcher.jar" }) {
 				final FileObject dependency = files.get(fileName);
 				if (dependency != null) {
 					file.addDependency(files, dependency);

--- a/src/main/java/net/imagej/updater/DefaultUploaderService.java
+++ b/src/main/java/net/imagej/updater/DefaultUploaderService.java
@@ -92,9 +92,9 @@ public class DefaultUploaderService extends AbstractService implements
 	public Uploader installUploader(String protocol, FilesCollection files, final Progress progress) {
 		if (hasUploader(protocol)) return getUploader(protocol);
 
-		FileObject uploader = files.get("jars/ij-updater-" + protocol + ".jar");
+		FileObject uploader = files.get("jars/imagej-plugins-uploader-" + protocol + ".jar");
 		if (uploader == null && "sftp".equals(protocol)) {
-			uploader = files.get("jars/ij-updater-ssh.jar");
+			uploader = files.get("jars/imagej-plugins-uploader-ssh.jar");
 		}
 		if (uploader == null) {
 			throw new IllegalArgumentException("No uploader found for protocol " + protocol);

--- a/src/main/java/net/imagej/updater/Installer.java
+++ b/src/main/java/net/imagej/updater/Installer.java
@@ -168,7 +168,7 @@ public class Installer extends Downloader {
 		final Set<FileObject> topLevel = new HashSet<FileObject>();
 		topLevel.add(updater);
 		if (commandService == null) {
-			final String hardcoded = "jars/ij-ui-swing-updater.jar";
+			final String hardcoded = "jars/imagej-ui-swing.jar";
 			final FileObject file = files.get(hardcoded);
 			if (file != null) topLevel.add(file);
 		} else {
@@ -198,13 +198,17 @@ public class Installer extends Downloader {
 
 	/**
 	 * Gets the file object for the .jar file containing the given class.
+	 * <p>
+	 * To deal with version skew properly, we avoid using SciJava common's
+	 * {@link org.scijava.util.FileUtils} here.
+	 * </p>
 	 * 
-	 * Unfortunately, at the time of writing, we could not rely on ij-core being updated properly when ij-updater-core was updated,
-	 * so we had to invent this method which logically belongs into imagej.util.FileUtils.
-	 * 
-	 * @param files the database of available files
-	 * @param className the name of the class we seek the .jar file for
-	 * @return the file object, or null if the class could not be found in any file of the collection
+	 * @param files
+	 *            the database of available files
+	 * @param className
+	 *            the name of the class we seek the .jar file for
+	 * @return the file object, or null if the class could not be found in any
+	 *         file of the collection
 	 */
 	private static FileObject getFileObject(final FilesCollection files, final String className) {
 		try {

--- a/src/main/java/net/imagej/updater/util/UpdaterUtil.java
+++ b/src/main/java/net/imagej/updater/util/UpdaterUtil.java
@@ -577,9 +577,9 @@ public class UpdaterUtil {
 
 	/**
 	 * Get a log service.
-	 *
-	 * This works around an earlier updater bug where it failed to update ij-core
-	 * properly, so the StderrLogService class was not found.
+	 * 
+	 * This works around version skews (where the
+	 * {@link org.scijava.log.StderrLogService} cannot be found).
 	 * 
 	 * @return the log service
 	 */

--- a/src/test/java/net/imagej/updater/CustomUploaderTest.java
+++ b/src/test/java/net/imagej/updater/CustomUploaderTest.java
@@ -54,9 +54,9 @@ import org.junit.Test;
  * <p>
  * When an update site has upload information for a protocol that no local
  * component can handle, we try to install the file
- * <i>jars/ij-updater-&lt;protocol&gt;-&lt;version&gt;.jar</i> (if it is
- * installable). This integration test verifies that that functionality is not
- * broken.
+ * <i>jars/imagej-plugins-uploader-&lt;protocol&gt;-&lt;version&gt;.jar</i> (if
+ * it is installable). This integration test verifies that that functionality is
+ * not broken.
  * </p>
  * 
  * @author Johannes Schindelin
@@ -103,7 +103,7 @@ public class CustomUploaderTest {
 		assertFalse(hasHobbes(files));
 
 		// copy the custom uploader to the working directory
-		final String filename = "ij-updater-hobbes-1.0.0-SNAPSHOT.jar";
+		final String filename = "imagej-plugins-uploader-hobbes-1.0.0-SNAPSHOT.jar";
 		final File target = files.prefix("jars/" + filename);
 		writeJar(target, clazz);
 

--- a/src/test/java/net/imagej/updater/UpdaterTest.java
+++ b/src/test/java/net/imagej/updater/UpdaterTest.java
@@ -498,7 +498,7 @@ public class UpdaterTest {
 	@Test
 	public void testStripVersionFromFilename() {
 		assertEquals("jars/bio-formats.jar", FileObject.getFilename("jars/bio-formats-4.4-imagej-2.0.0-beta1.jar", true));
-		assertEquals(FileObject.getFilename("jars/ij-data-2.0.0.1-beta1.jar", true), FileObject.getFilename("jars/ij-data-2.0.0.1-SNAPSHOT.jar", true));
+		assertEquals(FileObject.getFilename("jars/imagej-common-2.0.0.1-beta1.jar", true), FileObject.getFilename("jars/imagej-common-2.0.0.1-SNAPSHOT.jar", true));
 		assertEquals(FileObject.getFilename("jars/ij-1.44.jar", true), FileObject.getFilename("jars/ij-1.46b.jar", true));
 		assertEquals(FileObject.getFilename("jars/javassist.jar", true), FileObject.getFilename("jars/javassist-3.9.0.GA.jar", true));
 		assertEquals(FileObject.getFilename("jars/javassist.jar", true), FileObject.getFilename("jars/javassist-3.16.1-GA.jar", true));

--- a/src/test/java/net/imagej/updater/util/DependencyAnalyzerTest.java
+++ b/src/test/java/net/imagej/updater/util/DependencyAnalyzerTest.java
@@ -46,7 +46,7 @@ public class DependencyAnalyzerTest {
 	@Test
 	public void testDependencyAnalyzerExclusions() {
 		assertTrue(DependencyAnalyzer.exclude("jars/testng-6.8.jar", "jars/guice-2.0.jar"));
-		assertFalse(DependencyAnalyzer.exclude("jars/ij-legacy-2.0.1.jar", "jars/ij-1.47a.jar"));
+		assertFalse(DependencyAnalyzer.exclude("jars/imagej-legacy-2.0.1.jar", "jars/ij-1.47a.jar"));
 		assertTrue(DependencyAnalyzer.exclude("jars/MMCoreJ.jar", "plugins/MMJ_.jar"));
 		assertTrue(DependencyAnalyzer.exclude("plugins/MMCoreJ.jar", "plugins/MMJ_.jar"));
 	}


### PR DESCRIPTION
We renamed a couple of components recently (in conjunction with a lot
of restructuring, including a move to the net.imagej.\* packages). The
updater was unfortunately left behind, still thinking that the naming
convention is "ij-_.jar" instead of "imagej-_.jar".

This oversight was noticed when Jérôme Mutterer reported that his
updater did not auto-install the 'ssh' uploader.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
