### PR TITLE
Support Micro-Manager update sites

### DIFF
--- a/src/main/java/net/imagej/updater/Checksummer.java
+++ b/src/main/java/net/imagej/updater/Checksummer.java
@@ -413,6 +413,10 @@ public class Checksummer extends AbstractProgressable {
 				file.filename.substring(4);
 			else if (file.filename.startsWith("mm/")) platform =
 				file.filename.substring(3);
+			else if (file.filename.startsWith("OlympusIX3Control/")) {
+				file.addPlatform("win32");
+				return true;
+			}
 			else return false;
 
 			final int slash = platform.indexOf('/');


### PR DESCRIPTION
There is a special-purpose top-level directory in Micro-Manager called `OlympusIX3Control`. It is quite the fiddly thing, moving the files elsewhere might break everything, and it is hard to test whether it does because Olympus did not bother to equip the Micro-Manager team with a test system.

So let's do the next best thing (because the best solution is obviously out of our reach): bite the apple and add that specific directory as a known one to the updater. May it serve as a counter-example to hardware vendors. It is in their interest to make their hardware _more_ accessible to scientists, after all, not _less_.
