### PR TITLE
UpToDate: improve detection of developer setting

### DIFF
--- a/src/main/java/net/imagej/updater/UpToDate.java
+++ b/src/main/java/net/imagej/updater/UpToDate.java
@@ -154,10 +154,11 @@ public class UpToDate {
 	}
 
 	/**
-	 * @return whether we started in a developer setting (classes are not in .jar files)
+	 * @return whether we started in a developer setting (i.e., not using the
+	 *         Launcher, which sets the imagej.dir property)
 	 */
 	public static boolean isDeveloper() {
-		return UpToDate.class.getResource("UpToDate.class").toString().startsWith("file:");
+		return System.getProperty("imagej.dir") == null;
 	}
 
 	/**


### PR DESCRIPTION
The previous detection was failing when launching `net.imagej.Main` from
Eclipse—and probably in many other scenarios, too—due to the fact
that we now use release couplings by default. So
`net.imagej.updater.UpToDate.class` _will_ be located in a JAR file, even
when running from the IDE. But the `imagej.dir` property is normally not
set in that scenario, since only the ImageJ Launcher sets it by default.

Of course, you could set `imagej.dir` in your Run configuration, which
would defeat this heuristic. But this approach should work for most
people most of the time...
