### PR TITLE
Fix two issues with update sites

### DIFF
--- a/src/main/java/net/imagej/updater/FilesCollection.java
+++ b/src/main/java/net/imagej/updater/FilesCollection.java
@@ -130,7 +130,6 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 
 	public UpdateSite addUpdateSite(UpdateSite site) {
 		addUpdateSite(site.getName(), site);
-		setUpdateSitesChanged(true);
 		return site;
 	}
 
@@ -139,6 +138,7 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 		updateSite.rank = already != null ? already.rank : updateSites.size();
 		if (already != null) updateSite.setOfficial(already.isOfficial());
 		updateSites.put(name,  updateSite);
+		if (updateSite != already) setUpdateSitesChanged(true);
 	}
 
 	public void renameUpdateSite(final String oldName, final String newName) {

--- a/src/main/java/net/imagej/updater/FilesCollection.java
+++ b/src/main/java/net/imagej/updater/FilesCollection.java
@@ -162,7 +162,7 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 	}
 
 	public void removeUpdateSite(final String name) {
-		for (final FileObject file : forUpdateSite(name)) {
+		for (final FileObject file : clone(forUpdateSite(name))) {
 			file.removeFromUpdateSite(name, this);
 		}
 		updateSites.remove(name);


### PR DESCRIPTION
These are not really biggies, but they both came up when I tried to write a script that will ensure that the Micro-Manager-dev update site is enabled at the same time that the OpenSPIM update site is enabled, too.