### PR TITLE
Support Groovy scripts

### DIFF
--- a/src/main/java/net/imagej/updater/Checksummer.java
+++ b/src/main/java/net/imagej/updater/Checksummer.java
@@ -435,8 +435,8 @@ public class Checksummer extends AbstractProgressable {
 
 	public static final String[][] directories = {
 		{ "jars", "retro", "misc" }, { ".jar", ".class" },
-		{ "plugins" }, { ".jar", ".class", ".txt", ".ijm", ".py", ".rb", ".clj", ".js", ".bsh" },
-		{ "scripts" }, { ".py", ".rb", ".clj", ".js", ".bsh", ".m" },
+		{ "plugins" }, { ".jar", ".class", ".txt", ".ijm", ".py", ".rb", ".clj", ".js", ".bsh", ".groovy", ".gvy" },
+		{ "scripts" }, { ".py", ".rb", ".clj", ".js", ".bsh", ".m", ".groovy", ".gvy" },
 		{ "macros" }, { ".txt", ".ijm" },
 		{ "luts" }, { ".lut" },
 		{ "images" }, { ".png", ".tif", ".txt" },


### PR DESCRIPTION
Currently Groovy files are not recognized by the updater.
I noticed this when I could not upload the [Groovy lib](https://github.com/tferr/Scripts/blob/master/lib/BARlib.groovy) to the BAR update site.
NB: AFAICT there are also other extensions (.gy, .gsh) that the `groovy` command recognizes but those are likely very unpopular. 