### PR TITLE
Fix Fiji update site check

### DIFF
--- a/src/main/java/net/imagej/updater/util/AvailableSites.java
+++ b/src/main/java/net/imagej/updater/util/AvailableSites.java
@@ -108,7 +108,7 @@ public final class AvailableSites {
 		}
 		if (!iter.hasNext()) throw new IOException("Invalid page: " + SITE_LIST_PAGE_TITLE);
 		site = iter.next();
-		if (!site.getName().equals("Fiji") || !site.getURL().equals("http://fiji.sc/update/")) {
+		if (!site.getName().equals("Fiji") || !site.getURL().equals("http://update.fiji.sc/")) {
 			throw new IOException("Invalid page: " + SITE_LIST_PAGE_TITLE);
 		}
 


### PR DESCRIPTION
After @ctrueden 's recent change on the [List of update sites](http://fiji.sc/index.php?title=List_of_update_sites&diff=next&oldid=15648), the updater was throwing the exception below. This change should fix it.

    java.io.IOException: Invalid page: List of update sites
	at net.imagej.updater.util.AvailableSites.getAvailableSites(AvailableSites.java:112)
	at net.imagej.updater.util.AvailableSites.initializeSites(AvailableSites.java:138)
	at net.imagej.updater.util.AvailableSites.initializeAndAddSites(AvailableSites.java:187)
	at net.imagej.ui.swing.updater.ImageJUpdater.run(ImageJUpdater.java:107)
	at org.scijava.command.CommandModule.run(CommandModule.java:201)
	at org.scijava.module.ModuleRunner.run(ModuleRunner.java:167)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:126)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:65)
	at org.scijava.thread.DefaultThreadService$2.call(DefaultThreadService.java:191)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
    java.io.IOException: Invalid page: List of update sites
	at net.imagej.updater.util.AvailableSites.getAvailableSites(AvailableSites.java:112)
	at net.imagej.updater.util.AvailableSites.initializeSites(AvailableSites.java:138)
	at net.imagej.updater.util.AvailableSites.initializeAndAddSites(AvailableSites.java:187)
	at net.imagej.ui.swing.updater.ImageJUpdater.run(ImageJUpdater.java:107)
	at org.scijava.command.CommandModule.run(CommandModule.java:201)
	at org.scijava.module.ModuleRunner.run(ModuleRunner.java:167)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:126)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:65)
	at org.scijava.thread.DefaultThreadService$2.call(DefaultThreadService.java:191)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)