### PR TITLE
Add scijava-ui-swing and imglib2 for uploading to update sites

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -34,7 +34,9 @@ jars = [
 	'scijava-common-2.44.2.jar-20150720161756',
 	'imagej-common-0.14.0.jar-20150415222444',
 	'eventbus-1.4.jar-20120404210913',
-	'gentyref-1.1.0.jar-20140516211031'
+	'gentyref-1.1.0.jar-20140516211031',
+	'scijava-ui-swing-0.7.1.jar-20151122015629',
+	'imglib2-2.4.1.jar-20151122015629'
 ];
 
 isCommandLine = typeof arguments != 'undefined';


### PR DESCRIPTION
While I tried to upload the SPIMAcquisition plugin in the openspim update site yesterday, there were two ClassNotFoundException. One is about scijava-ui-swing and the other is about imglib2. I am not sure if this is happening only in my case or not. After adding two jar files, I managed to upload new SPIMAcquisition plugin. If you think it is irrelevant in your use cases, simply reject it.
