### PR TITLE
changed level of annoying message from warn to debug

### DIFF
--- a/src/main/java/net/imagej/updater/FilesCollection.java
+++ b/src/main/java/net/imagej/updater/FilesCollection.java
@@ -922,7 +922,7 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 			if (other == null || overriding != dependency.overrides ||
 				!other.isUpdateablePlatform(this)) continue;
 			if (other.isObsolete() && other.willNotBeInstalled()) {
-				log.warn("Ignoring obsolete dependency " + dependency.filename
+				log.debug("Ignoring obsolete dependency " + dependency.filename
 						+ " of " + file.filename);
 				continue;
 			}


### PR DESCRIPTION
A normal ImageJ/Fiji  user should not be bothered with popping up console windows with messages like "Ignoring obsolete dependency". He cannot know what it means. It suggests him, that he did something wrong, which is not the case. He just activated another update site and the installed plugins run fine.