### PR TITLE
Fix parsing of protocol/username/hostname from host string (issue #53)

### DIFF
--- a/src/main/java/net/imagej/updater/FilesUploader.java
+++ b/src/main/java/net/imagej/updater/FilesUploader.java
@@ -145,24 +145,16 @@ public class FilesUploader {
 	}
 
 	public String getDefaultUsername() {
-		String host = site.getHost();
-		if (host.startsWith("sftp:")) host = host.substring(5);
-		final int at = host.indexOf('@');
-		if (at > 0) return host.substring(0, at);
-		final String name = UpdaterUserInterface.get().getPref(UpdaterUtil.PREFS_USER);
-		if (name == null) return "";
-		return name;
+		String username = site.getUploadUsername();
+		if (username  == null)
+			username = UpdaterUserInterface.get().getPref(UpdaterUtil.PREFS_USER);
+		if (username  == null)
+			username = "";
+		return username;
 	}
 
 	public String getUploadHost() {
-		String host = site.getHost();
-		if (uploader != null) {
-			final String protocol = uploader.getProtocol();
-			if (protocol != null && host.startsWith(protocol + ":")) {
-				host = host.substring(protocol.length() + 1);
-			}
-		}
-		return host.substring(host.indexOf('@') + 1);
+		return site.getUploadHost();
 	}
 
 	public String getUploadDirectory() {

--- a/src/main/java/net/imagej/updater/UpdateSite.java
+++ b/src/main/java/net/imagej/updater/UpdateSite.java
@@ -51,6 +51,9 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 	private String name;
 	private String url;
 	private String host;
+	private String upload_protocol;
+	private String upload_username;
+	private String upload_host;
 	private String uploadDirectory;
 	private String description;
 	private String maintainer;
@@ -119,6 +122,25 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 
 	public void setHost(final String host) {
 		this.host = host;
+		if (host == null) {
+			this.upload_protocol = null;
+			this.upload_username = null;
+			this.upload_host = null;
+		} else {
+			final int colon = host.indexOf(':');
+			if (colon < 0)
+				this.upload_protocol = null;
+			else
+				this.upload_protocol = host.substring(0, colon);
+
+			final int at = host.indexOf('@');
+			if (at < 0)
+				this.upload_username = null;
+			else
+				this.upload_username = host.substring(colon+1, at);
+
+			this.upload_host = host.substring(at+1);
+		}
 	}
 
 	public String getUploadDirectory() {
@@ -205,10 +227,17 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 	public String getUploadProtocol() {
 		if (host == null)
 			throw new RuntimeException("Missing upload information for site " + url);
-		final int at = host.indexOf('@');
-		final int colon = host.indexOf(':');
-		if (colon > 0 && (at < 0 || colon < at)) return host.substring(0, colon);
-		return "ssh";
+		return this.upload_protocol;
+	}
+	public String getUploadUsername() {
+		if (host == null)
+			throw new RuntimeException("Missing upload information for site " + url);
+		return this.upload_username;
+	}
+	public String getUploadHost() {
+		if (host == null)
+			throw new RuntimeException("Missing upload information for site " + url);
+		return this.upload_host;
 	}
 
 	// -- Helper methods --


### PR DESCRIPTION
FilesUploader: remove logic of parsing the host string which is kinda
duplicated and have it as part of the UpdateSite class.
UpdateSite: set the upload protocol, username, and hostname as part of
setting the host string.