### PR TITLE
Adding removal timestamp to previous version of file

### DIFF
--- a/src/main/java/net/imagej/updater/CommandLine.java
+++ b/src/main/java/net/imagej/updater/CommandLine.java
@@ -857,7 +857,7 @@ public class CommandLine {
 					log.info("Would upload '" + name + "'");
 				}
 				if (file.localFilename != null && !file.localFilename.equals(file.filename)) {
-					file.addPreviousVersion(file.current.checksum, file.current.timestamp, file.filename);
+					file.addPreviousVersion(file.current.checksum, file.current.timestamp, file.filename, 0);
 				}
 				file.setAction(files, Action.UPLOAD);
 			}

--- a/src/main/java/net/imagej/updater/FilesUploader.java
+++ b/src/main/java/net/imagej/updater/FilesUploader.java
@@ -224,7 +224,7 @@ public class FilesUploader {
 				file.localFilename != null && !file.localFilename.equals(file.filename))
 			{
 				file.addPreviousVersion(file.current.checksum, file.current.timestamp,
-					file.filename);
+					file.filename, 0);
 				file.setAction(files, Action.UPLOAD);
 			}
 		}

--- a/src/main/java/net/imagej/updater/XMLFileReader.java
+++ b/src/main/java/net/imagej/updater/XMLFileReader.java
@@ -164,7 +164,7 @@ public class XMLFileReader extends DefaultHandler {
 			if ("true".equalsIgnoreCase(executable)) current.executable = true;
 		}
 		else if (currentTag.equals("previous-version")) current.addPreviousVersion(
-			atts.getValue("checksum"), getLong(atts, "timestamp"), atts.getValue("filename"));
+			atts.getValue("checksum"), getLong(atts, "timestamp"), atts.getValue("filename"), getLong(atts, "timestamp-obsolete"));
 		else if (currentTag.equals("version")) {
 			current.setVersion(atts.getValue("checksum"), getLong(atts, "timestamp"));
 			current.filesize = getLong(atts, "filesize");
@@ -309,10 +309,10 @@ public class XMLFileReader extends DefaultHandler {
 
 	private static void addPreviousVersions(FileObject from, FileObject to) {
 		if (from.current != null) {
-			to.addPreviousVersion(from.current.checksum, from.current.timestamp, from.getLocalFilename(false));
+			to.addPreviousVersion(from.current.checksum, from.current.timestamp, from.getLocalFilename(false), 0);
 		}
 		for (final FileObject.Version version : from.previous) {
-			to.addPreviousVersion(version.checksum, version.timestamp, version.filename);
+			to.addPreviousVersion(version);
 		}
 	}
 

--- a/src/main/java/net/imagej/updater/XMLFileWriter.java
+++ b/src/main/java/net/imagej/updater/XMLFileWriter.java
@@ -50,6 +50,7 @@ import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
 
+import net.imagej.updater.util.UpdaterUtil;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -108,6 +109,7 @@ public class XMLFileWriter {
 		+ "<!ATTLIST version filesize CDATA #REQUIRED>\n"
 		+ "<!ATTLIST previous-version filename CDATA #IMPLIED>\n"
 		+ "<!ATTLIST previous-version timestamp CDATA #REQUIRED>\n"
+		+ "<!ATTLIST previous-version timestamp-obsolete CDATA #IMPLIED>\n"
 		+ "<!ATTLIST previous-version checksum CDATA #REQUIRED>]>\n";
 
 	public XMLFileWriter(final FilesCollection files) {
@@ -206,11 +208,14 @@ public class XMLFileWriter {
 			writeSimpleTags("author", file.getAuthors());
 			handler.endElement("", "", "version");
 		}
-		if (current != null && !current.checksum.equals(file.getChecksum())) file
-			.addPreviousVersion(current.checksum, current.timestamp, current.filename);
+		if (current != null && !current.checksum.equals(file.getChecksum())) {
+			current.timestampObsolete = UpdaterUtil.currentTimestamp();
+			file.addPreviousVersion(current);
+		}
 		for (final FileObject.Version version : file.getPrevious()) {
 			attr.clear();
 			setAttribute(attr, "timestamp", version.timestamp);
+			setAttribute(attr, "timestamp-obsolete", version.timestampObsolete);
 			setAttribute(attr, "checksum", version.checksum);
 			if (version.filename != null) setAttribute(attr, "filename", version.filename);
 			writeSimpleTag("previous-version", null, attr);

--- a/src/main/java/net/imagej/updater/util/UpdaterUtil.java
+++ b/src/main/java/net/imagej/updater/util/UpdaterUtil.java
@@ -273,6 +273,10 @@ public class UpdaterUtil {
 
 	}
 
+	public static long currentTimestamp() {
+		return Long.parseLong(UpdaterUtil.timestamp(Calendar.getInstance()));
+	}
+
 	public static long getTimestamp(final File file) {
 		final long modified = file.lastModified();
 		return Long.parseLong(timestamp(modified));

--- a/src/test/java/net/imagej/updater/UpdaterTest.java
+++ b/src/test/java/net/imagej/updater/UpdaterTest.java
@@ -51,11 +51,8 @@ import static net.imagej.updater.UpdaterTestUtils.upload;
 import static net.imagej.updater.UpdaterTestUtils.writeFile;
 import static net.imagej.updater.UpdaterTestUtils.writeGZippedFile;
 import static net.imagej.updater.UpdaterTestUtils.writeJar;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -939,7 +936,7 @@ public class UpdaterTest {
 			final FileObject file =
 				new FileObject(null, "jars/new.jar", jar.length(), triplet[1], UpdaterUtil
 					.getTimestamp(jar), Status.NOT_INSTALLED);
-			file.addPreviousVersion(triplet[0], 1, null);
+			file.addPreviousVersion(triplet[0], 1, null, 0);
 			files.add(file);
 			files.prefix(".checksums").delete();
 			new Checksummer(files, progress).updateFromLocal();
@@ -1142,6 +1139,11 @@ public class UpdaterTest {
 		final File webRoot = getWebRoot(files);
 		String db = readGzippedStream(new FileInputStream(new File(webRoot, "db.xml.gz")));
 		assertTrue(db.indexOf("<plugin filename=\"jars/obsolete.jar\"") > 0);
+		FileObject obsoleteFile = files.get("jars/obsolete.jar");
+		assertNotNull(obsoleteFile);
+		assertNull(obsoleteFile.current);
+		assertCount(1, obsoleteFile.previous);
+		assertNotEquals(0, obsoleteFile.previous.iterator().next().timestampObsolete);
 	}
 
 	@Test
@@ -1253,7 +1255,7 @@ public class UpdaterTest {
 		final FileObject file =
 			new FileObject(FilesCollection.DEFAULT_UPDATE_SITE, "jars/new.jar", jar.length(), checksumOld, UpdaterUtil
 				.getTimestamp(jar), Status.INSTALLED);
-		file.addPreviousVersion(checksumNew, UpdaterUtil.getTimestamp(jar) - 1l, null);
+		file.addPreviousVersion(checksumNew, UpdaterUtil.getTimestamp(jar) - 1l, null, 0);
 		files.add(file);
 
 		final File webRoot = getWebRoot(files);


### PR DESCRIPTION
This PR introduces a timestamp entry to the database file indicating when a version was marked as obsolete (= when it became a previous-version). 

I was investigating how an ImageJ installation would look like in a previous time point based on the activated update sites and it seemed to be impossible to tell when a file was marked as obsolete.

I also added a test to check if this timestamp is not 0 once a file is marked and uploaded as obsolete.