### PR TITLE
New Updater V1 (using HTTPS update sites if certificate supported)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<artifactId>scijava-common</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+		</dependency>
+
 		<!-- Test scope dependencies -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,18 @@
 				<role>maintainer</role>
 			</roles>
 		</developer>
+		<developer>
+			<id>frauzufall</id>
+			<name>Deborah Schmidt</name>
+			<url>https://imagej.net/User:Frauzufall</url>
+			<roles>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
 	</developers>
 	<contributors>
 		<contributor>
@@ -71,6 +83,11 @@
 			<name>Mark Hiner</name>
 			<url>http://imagej.net/User:Hinerm</url>
 			<properties><id>hinerm</id></properties>
+		</contributor>
+		<contributor>
+			<name>Matthias Arzt</name>
+			<url>https://imagej.net/User:Maarzt</url>
+			<properties><id>maarzt</id></properties>
 		</contributor>
 	</contributors>
 

--- a/src/main/java/net/imagej/updater/DefaultUpdateService.java
+++ b/src/main/java/net/imagej/updater/DefaultUpdateService.java
@@ -38,6 +38,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import net.imagej.updater.util.AvailableSites;
 
+import net.imagej.updater.util.HTTPSUtil;
 import org.scijava.app.AppService;
 import org.scijava.command.CommandService;
 import org.scijava.event.EventHandler;
@@ -122,6 +123,7 @@ public class DefaultUpdateService extends AbstractService implements
 		final FilesCollection fc = new FilesCollection(rootDir());
 
 		// parse the official list of update sites
+		HTTPSUtil.checkHTTPSSupport(log);
 		AvailableSites.initializeAndAddSites(fc);
 
 		// parse the user's update site database (db.xml.gz)

--- a/src/main/java/net/imagej/updater/FilesCollection.java
+++ b/src/main/java/net/imagej/updater/FilesCollection.java
@@ -63,10 +63,7 @@ import net.imagej.updater.action.KeepAsIs;
 import net.imagej.updater.action.Remove;
 import net.imagej.updater.action.Uninstall;
 import net.imagej.updater.action.Upload;
-import net.imagej.updater.util.DependencyAnalyzer;
-import net.imagej.updater.util.Progress;
-import net.imagej.updater.util.UpdateCanceledException;
-import net.imagej.updater.util.UpdaterUtil;
+import net.imagej.updater.util.*;
 
 import org.scijava.log.LogService;
 import org.xml.sax.SAXException;
@@ -1132,7 +1129,7 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 				// make sure that the Fiji update site is enabled
 				UpdateSite fiji = getUpdateSite("Fiji", true);
 				if (fiji == null) {
-					addUpdateSite("Fiji", "http://update.fiji.sc/", null, null, 0);
+					addUpdateSite("Fiji", HTTPSUtil.getProtocol() + "update.fiji.sc/", null, null, 0);
 				}
 			}
 		}

--- a/src/main/java/net/imagej/updater/FilesCollection.java
+++ b/src/main/java/net/imagej/updater/FilesCollection.java
@@ -1120,7 +1120,7 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 		};
 	}
 
-	public String downloadIndexAndChecksum(final Progress progress) throws ParserConfigurationException, SAXException {
+	public void tryLoadingCollection() throws ParserConfigurationException, SAXException {
 		try {
 			read();
 		}
@@ -1134,7 +1134,9 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 			}
 		}
 		catch (final IOException e) { /* ignore */ }
+	}
 
+	public String reloadCollectionAndChecksum(final Progress progress) {
 		// clear the files
 		clear();
 
@@ -1143,8 +1145,8 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 		try {
 			downloader.start(false);
 		} catch (final UpdateCanceledException e) {
-				downloader.done();
-				throw e;
+			downloader.done();
+			throw e;
 		}
 		new Checksummer(this, progress).updateFromLocal();
 
@@ -1158,6 +1160,11 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 		}
 
 		return downloader.getWarnings();
+	}
+
+	public String downloadIndexAndChecksum(final Progress progress) throws ParserConfigurationException, SAXException {
+		tryLoadingCollection();
+		return reloadCollectionAndChecksum(progress);
 	}
 
 	public List<Conflict> getConflicts() {

--- a/src/main/java/net/imagej/updater/URLChange.java
+++ b/src/main/java/net/imagej/updater/URLChange.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2019 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.updater;
+
+import java.util.Optional;
+
+/**
+ * Class indicating automated changes to an update site.
+ * These changes need to get approved for active updates.
+ *
+ * @author Deborah Schmidt
+ */
+public class URLChange {
+
+	private final UpdateSite site;
+
+	private final String newUrl;
+
+	private final boolean recommended;
+
+	private boolean approved = false;
+
+	/**
+	 * Proposes a new URL for this update site. The new URL will not be marked as recommended if:
+	 * - the current update site URL is a mirror URL OR
+	 * - the site is on the list of available update sites and the URL got manually modified
+	 * @param newUrl the new URL
+	 */
+	public static Optional< URLChange > create(UpdateSite site, String newUrl) {
+		newUrl = UpdateSite.format(newUrl);
+		if(site.getURL().equals(newUrl)) return Optional.empty();
+		return Optional.of( new URLChange(site, newUrl) );
+	}
+
+	private URLChange(UpdateSite site, String newUrl) {
+		this.site = site;
+		this.newUrl = newUrl;
+		this.recommended = !site.shouldKeepURL() && ! isMirror(site);
+		this.approved = recommended && ! site.isActive();
+	}
+
+	public UpdateSite updateSite()
+	{
+		return site;
+	}
+
+	public boolean isApproved() {
+		return approved;
+	}
+
+	public void applyIfApproved() {
+		if(newUrl == null) return;
+		if(approved) {
+			site.setURL(newUrl);
+			site.setKeepURL(false);
+		}
+	}
+
+	public String toString() {
+		return "new URL: " + newUrl + ", " + " approved: " + approved;
+	}
+
+	public void setApproved(boolean approved) {
+		this.approved = approved;
+	}
+
+	public String getNewURL() {
+		return newUrl;
+	}
+
+	public boolean isRecommended() {
+		return recommended;
+	}
+
+	/**
+	 * Helper function checking if an update site URL is a known mirror URL.
+	 */
+	private static boolean isMirror(UpdateSite site) {
+		// NB: This might be changed into an extensible list of mirrors in the future.
+		return site.getURL().startsWith("https://downloads.micron.ox.ac.uk");
+	}
+
+}

--- a/src/main/java/net/imagej/updater/UpToDate.java
+++ b/src/main/java/net/imagej/updater/UpToDate.java
@@ -45,6 +45,7 @@ import java.util.Enumeration;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import net.imagej.updater.util.HTTPSUtil;
 import net.imagej.updater.util.UpdaterUtil;
 
 import org.scijava.util.AppUtils;
@@ -108,6 +109,7 @@ public class UpToDate {
 				plugins.read();
 			}
 			catch (final FileNotFoundException e) { /* ignore */}
+			HTTPSUtil.checkHTTPSSupport(null);
 			for (final String name : plugins.getUpdateSiteNames(false)) {
 				final UpdateSite updateSite = plugins.getUpdateSite(name, true);
 				final long lastModified =

--- a/src/main/java/net/imagej/updater/UpToDate.java
+++ b/src/main/java/net/imagej/updater/UpToDate.java
@@ -45,6 +45,7 @@ import java.util.Enumeration;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import net.imagej.updater.util.AvailableSites;
 import net.imagej.updater.util.HTTPSUtil;
 import net.imagej.updater.util.UpdaterUtil;
 
@@ -110,6 +111,9 @@ public class UpToDate {
 			}
 			catch (final FileNotFoundException e) { /* ignore */}
 			HTTPSUtil.checkHTTPSSupport(null);
+			if(AvailableSites.hasUpdateSiteURLUpdates(plugins)) {
+				return Result.UPDATEABLE;
+			}
 			for (final String name : plugins.getUpdateSiteNames(false)) {
 				final UpdateSite updateSite = plugins.getUpdateSite(name, true);
 				final long lastModified =

--- a/src/main/java/net/imagej/updater/UpdateSite.java
+++ b/src/main/java/net/imagej/updater/UpdateSite.java
@@ -31,6 +31,7 @@
 
 package net.imagej.updater;
 
+import net.imagej.updater.util.HTTPSUtil;
 import net.imagej.updater.util.UpdaterUtil;
 
 /**
@@ -216,9 +217,8 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 	/** Rewrites known-obsolete URLs to the current ones. */
 	private void rewriteOldURLs() {
 		if ("http://pacific.mpi-cbg.de/update/".equals(url) ||
-			"http://fiji.sc/update/".equals(url))
-		{
-			url = "http://update.fiji.sc/";
+				"http://fiji.sc/update/".equals(url)) {
+			url = HTTPSUtil.getProtocol() + "update.fiji.sc/";
 		}
 	}
 

--- a/src/main/java/net/imagej/updater/UpdateSite.java
+++ b/src/main/java/net/imagej/updater/UpdateSite.java
@@ -51,6 +51,8 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 	private boolean official;
 	private String name;
 	private String url;
+	private boolean keepURLModification;
+
 	private String host;
 	private String uploadDirectory;
 	private String description;
@@ -59,7 +61,7 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 	int rank;
 
 	public UpdateSite(final String name, String url, final String sshHost, String uploadDirectory,
-		final String description, final String maintainer, final long timestamp)
+	                  final String description, final String maintainer, final long timestamp)
 	{
 		setName(name);
 		setURL(url);
@@ -108,10 +110,9 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 		return url;
 	}
 
-	public void setURL(final String url) {
-		if (url == null || url.equals("") || url.endsWith("/")) this.url = url;
-		else this.url = url + "/";
-		rewriteOldURLs();
+	public void setURL(String url) {
+		url = format(url);
+		this.url = url;
 	}
 
 	public String getHost() {
@@ -182,7 +183,7 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 
 	@Override
 	public String toString() {
-		return url + (host != null ? ", " + host : "") +
+		return getURL() + (host != null ? ", " + host : "") +
 			(uploadDirectory != null ? ", " + uploadDirectory : "");
 	}
 
@@ -212,14 +213,29 @@ public class UpdateSite implements Cloneable, Comparable<UpdateSite> {
 		return "ssh";
 	}
 
-	// -- Helper methods --
-
-	/** Rewrites known-obsolete URLs to the current ones. */
-	private void rewriteOldURLs() {
-		if ("http://pacific.mpi-cbg.de/update/".equals(url) ||
-				"http://fiji.sc/update/".equals(url)) {
-			url = HTTPSUtil.getProtocol() + "update.fiji.sc/";
-		}
+	public boolean shouldKeepURL() {
+		return keepURLModification;
 	}
 
+	public void setKeepURL(boolean keepURL) {
+		this.keepURLModification = keepURL;
+	}
+
+	public static String format(String url) {
+		if(url == null || url.isEmpty()) return url;
+		if (!url.endsWith("/")) {
+			url += "/";
+		}
+		url = rewriteOldURLs(url);
+		return url;
+	}
+
+	/** Rewrites known-obsolete URLs to the current ones. */
+	private static String rewriteOldURLs(String url) {
+		if ("http://pacific.mpi-cbg.de/update/".equals(url) ||
+				"http://fiji.sc/update/".equals(url)) {
+			return HTTPSUtil.getProtocol() + "update.fiji.sc/";
+		}
+		return url;
+	}
 }

--- a/src/main/java/net/imagej/updater/XMLFileReader.java
+++ b/src/main/java/net/imagej/updater/XMLFileReader.java
@@ -189,6 +189,9 @@ public class XMLFileReader extends DefaultHandler {
 			if(official != null) {
 				site.setOfficial(Boolean.valueOf(official));
 			}
+			String keepURL = atts.getValue("keep-url");
+			if(keepURL == null) site.setKeepURL(false);
+			site.setKeepURL(Boolean.valueOf(keepURL));
 			site.setActive(currentTag.equals("update-site"));
 			files.addUpdateSite(site);
 		}

--- a/src/main/java/net/imagej/updater/XMLFileReader.java
+++ b/src/main/java/net/imagej/updater/XMLFileReader.java
@@ -185,6 +185,10 @@ public class XMLFileReader extends DefaultHandler {
 					atts.getValue("description"),
 					atts.getValue("maintainer"),
 					Long.parseLong(atts.getValue("timestamp")));
+			String official = atts.getValue("official");
+			if(official != null) {
+				site.setOfficial(Boolean.valueOf(official));
+			}
 			site.setActive(currentTag.equals("update-site"));
 			files.addUpdateSite(site);
 		}

--- a/src/main/java/net/imagej/updater/XMLFileWriter.java
+++ b/src/main/java/net/imagej/updater/XMLFileWriter.java
@@ -86,6 +86,7 @@ public class XMLFileWriter {
 		+ "<!ELEMENT platform (#PCDATA)>\n" + "<!ELEMENT category (#PCDATA)>\n"
 		+ "<!ATTLIST update-site name CDATA #REQUIRED>\n"
 		+ "<!ATTLIST update-site url CDATA #REQUIRED>\n"
+		+ "<!ATTLIST update-site official CDATA #IMPLIED>\n"
 		+ "<!ATTLIST update-site ssh-host CDATA #IMPLIED>\n"
 		+ "<!ATTLIST update-site upload-directory CDATA #IMPLIED>\n"
 		+ "<!ATTLIST update-site description CDATA #IMPLIED>\n"
@@ -93,6 +94,7 @@ public class XMLFileWriter {
 		+ "<!ATTLIST update-site timestamp CDATA #REQUIRED>\n"
 		+ "<!ATTLIST disabled-update-site name CDATA #REQUIRED>\n"
 		+ "<!ATTLIST disabled-update-site url CDATA #REQUIRED>\n"
+		+ "<!ATTLIST disabled-update-site official CDATA #IMPLIED>\n"
 		+ "<!ATTLIST disabled-update-site ssh-host CDATA #IMPLIED>\n"
 		+ "<!ATTLIST disabled-update-site upload-directory CDATA #IMPLIED>\n"
 		+ "<!ATTLIST disabled-update-site description CDATA #IMPLIED>\n"
@@ -156,6 +158,7 @@ public class XMLFileWriter {
 				final UpdateSite site = files.getUpdateSite(name, true);
 				setAttribute(attr, "name", name);
 				setAttribute(attr, "url", site.getURL());
+				setAttribute(attr, "official", String.valueOf(site.isOfficial()));
 				if (site.getHost() != null) setAttribute(attr, "ssh-host", site.getHost());
 				if (site.getUploadDirectory() != null) setAttribute(attr,
 					"upload-directory", site.getUploadDirectory());

--- a/src/main/java/net/imagej/updater/XMLFileWriter.java
+++ b/src/main/java/net/imagej/updater/XMLFileWriter.java
@@ -86,6 +86,7 @@ public class XMLFileWriter {
 		+ "<!ELEMENT platform (#PCDATA)>\n" + "<!ELEMENT category (#PCDATA)>\n"
 		+ "<!ATTLIST update-site name CDATA #REQUIRED>\n"
 		+ "<!ATTLIST update-site url CDATA #REQUIRED>\n"
+		+ "<!ATTLIST update-site keep-url CDATA #IMPLIED>\n"
 		+ "<!ATTLIST update-site official CDATA #IMPLIED>\n"
 		+ "<!ATTLIST update-site ssh-host CDATA #IMPLIED>\n"
 		+ "<!ATTLIST update-site upload-directory CDATA #IMPLIED>\n"
@@ -94,6 +95,7 @@ public class XMLFileWriter {
 		+ "<!ATTLIST update-site timestamp CDATA #REQUIRED>\n"
 		+ "<!ATTLIST disabled-update-site name CDATA #REQUIRED>\n"
 		+ "<!ATTLIST disabled-update-site url CDATA #REQUIRED>\n"
+		+ "<!ATTLIST disabled-update-site keep-url CDATA #IMPLIED>\n"
 		+ "<!ATTLIST disabled-update-site official CDATA #IMPLIED>\n"
 		+ "<!ATTLIST disabled-update-site ssh-host CDATA #IMPLIED>\n"
 		+ "<!ATTLIST disabled-update-site upload-directory CDATA #IMPLIED>\n"
@@ -158,6 +160,9 @@ public class XMLFileWriter {
 				final UpdateSite site = files.getUpdateSite(name, true);
 				setAttribute(attr, "name", name);
 				setAttribute(attr, "url", site.getURL());
+				if(site.shouldKeepURL()) {
+					setAttribute(attr, "keep-url", String.valueOf(site.shouldKeepURL()));
+				}
 				setAttribute(attr, "official", String.valueOf(site.isOfficial()));
 				if (site.getHost() != null) setAttribute(attr, "ssh-host", site.getHost());
 				if (site.getUploadDirectory() != null) setAttribute(attr,

--- a/src/main/java/net/imagej/updater/util/AvailableSites.java
+++ b/src/main/java/net/imagej/updater/util/AvailableSites.java
@@ -46,6 +46,7 @@ import net.imagej.updater.UpdateSite;
 import net.imagej.util.MediaWikiClient;
 
 import org.scijava.log.LogService;
+import org.scijava.log.Logger;
 
 /**
  * Utility class for parsing the list of available update sites.
@@ -62,7 +63,16 @@ public final class AvailableSites {
 	private static final String SITE_LIST_PAGE_TITLE = "List of update sites";
 
 	public static Map<String, UpdateSite> getAvailableSites() throws IOException {
-		final MediaWikiClient wiki = new MediaWikiClient();
+		return getAvailableSites(null);
+	}
+
+	public static Map<String, UpdateSite> getAvailableSites(Logger log) throws IOException {
+		String wikiURL = HTTPSUtil.getProtocol() + "imagej.net/";
+
+		if(log != null) log.info("Reading available sites from " + wikiURL);
+		else System.out.println("[INFO] Reading available sites from " + wikiURL);
+
+		final MediaWikiClient wiki = new MediaWikiClient(wikiURL);
 		final String text = wiki.getPageSource(SITE_LIST_PAGE_TITLE);
 
 		final int start = text.indexOf("\n{| class=\"wikitable\"\n");
@@ -105,12 +115,14 @@ public final class AvailableSites {
 		final Iterator<UpdateSite> iter = result.values().iterator();
 		if (!iter.hasNext()) throw new IOException("Invalid page: " + SITE_LIST_PAGE_TITLE);
 		UpdateSite site = iter.next();
-		if (!site.getName().equals("ImageJ") || !site.getURL().equals("http://update.imagej.net/")) {
+		if (!site.getName().equals("ImageJ") || !site.getURL().equals(
+				HTTPSUtil.getProtocol() + "update.imagej.net/")) {
 			throw new IOException("Invalid page: " + SITE_LIST_PAGE_TITLE);
 		}
 		if (!iter.hasNext()) throw new IOException("Invalid page: " + SITE_LIST_PAGE_TITLE);
 		site = iter.next();
-		if (!site.getName().equals("Fiji") || !site.getURL().equals("http://update.fiji.sc/")) {
+		if (!site.getName().equals("Fiji") || !site.getURL().equals(
+				HTTPSUtil.getProtocol() + "update.fiji.sc/")) {
 			throw new IOException("Invalid page: " + SITE_LIST_PAGE_TITLE);
 		}
 

--- a/src/main/java/net/imagej/updater/util/AvailableSites.java
+++ b/src/main/java/net/imagej/updater/util/AvailableSites.java
@@ -31,22 +31,15 @@
 
 package net.imagej.updater.util;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import net.imagej.updater.URLChange;
 import net.imagej.updater.FilesCollection;
 import net.imagej.updater.UpdateSite;
 import net.imagej.util.MediaWikiClient;
-
-import org.scijava.log.LogService;
 import org.scijava.log.Logger;
+import org.xml.sax.SAXException;
+import javax.xml.transform.TransformerConfigurationException;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Utility class for parsing the list of available update sites.
@@ -56,9 +49,9 @@ import org.scijava.log.Logger;
  */
 public final class AvailableSites {
 
-  private AvailableSites() {
-    // NB: prevent instantiation of utility class
-  }
+	private AvailableSites() {
+		// NB: prevent instantiation of utility class
+	}
 
 	private static final String SITE_LIST_PAGE_TITLE = "List of update sites";
 
@@ -66,7 +59,7 @@ public final class AvailableSites {
 		return getAvailableSites(null);
 	}
 
-	public static Map<String, UpdateSite> getAvailableSites(Logger log) throws IOException {
+	public static Map<String, UpdateSite> getAvailableSites(final Logger log) throws IOException {
 		String wikiURL = HTTPSUtil.getProtocol() + "imagej.net/";
 
 		if(log != null) log.info("Reading available sites from " + wikiURL);
@@ -130,64 +123,106 @@ public final class AvailableSites {
 	}
 
 	/**
-	 * Parses the list of known update sites from the ImageJ wiki.
-	 * <p>
-	 * <strong>NB:</strong> This method does <em>not</em> add the sites to the
-	 * given {@link FilesCollection}! Use
-	 * {@link #initializeAndAddSites(FilesCollection)} for that.
-	 * </p>
+	 * As {@link #initializeAndAddSites(FilesCollection)} with an optional
+	 * {@link Logger} for reporting errors.
 	 */
-	public static List<UpdateSite> initializeSites(final FilesCollection files) {
-		return initializeSites(files, null);
+	public static List< URLChange > initializeAndAddSites(final FilesCollection files, final Logger log) {
+		return initializeAndAddSites(files, tryGetAvailableSites(log));
 	}
 
-	/**
-	 * As {@link #initializeSites(FilesCollection)} with an optional
-	 * {@link LogService} for reporting errors.
-	 */
-	public static List<UpdateSite> initializeSites(final FilesCollection files, final LogService log) {
+	static List< URLChange > initializeAndAddSites(
+			final FilesCollection files, final Collection< UpdateSite > availableSites)
+	{
+		final List< UpdateSite > sites = prepareAvailableUpdateSites(availableSites);
+		// method is package private to allow testing
+		ArrayList< URLChange > urlChanges = mergeLocalAndAvailabelUpdateSites(
+				files, sites);
+		makeSureNamesAreUnique(sites);
+		for (final UpdateSite site : sites) {
+			files.addUpdateSite(site);
+		}
+		return urlChanges;
+	}
+
+	private static List< UpdateSite > prepareAvailableUpdateSites(
+			Collection< UpdateSite > availableSites)
+	{
+		// method is package private to allow testing
+		for (final UpdateSite site : availableSites)
+			site.setURL(HTTPSUtil.fixImageJUserSiteProtocol(site.getURL()));
 		final List<UpdateSite> sites = new ArrayList<>();
-		final Map<String, Integer> url2index = new HashMap<>();
-
 		// make sure that the main update site is the first one.
-		final UpdateSite mainSite = new UpdateSite(FilesCollection.DEFAULT_UPDATE_SITE, UpdaterUtil.MAIN_URL, "", "", null, null, 0l);
-		mainSite.setOfficial(true);
-		sites.add(mainSite);
-		url2index.put(mainSite.getURL(), 0);
+		sites.add(initializeMainUpdateSite());
+		addAvailableUpdateSites(sites, availableSites);
+		return sites;
+	}
 
-		// read available sites from the ImageJ Wiki
+	private static Collection< UpdateSite > tryGetAvailableSites(Logger log)
+	{
 		try {
-			for (final UpdateSite site : getAvailableSites().values()) {
-				Integer index = url2index.get(site.getURL());
-				if (index == null) {
-					url2index.put(site.getURL(), sites.size());
-					sites.add(site);
-				} else {
-					sites.set(index.intValue(), site);
-				}
-			}
+			return getAvailableSites(log).values();
 		} catch (Exception e) {
 			if (log != null) log.error("Error processing available update sites from ImageJ wiki", e);
 			else e.printStackTrace();
+			return Collections.emptyList();
 		}
+	}
 
-		// add active / upload information
-		final Set<String> names = new HashSet<>();
-		for (final String name : files.getUpdateSiteNames(true)) {
-			final UpdateSite site = files.getUpdateSite(name, true);
-			Integer index = url2index.get(site.getURL());
+	private static UpdateSite initializeMainUpdateSite() {
+		final UpdateSite mainSite = new UpdateSite(FilesCollection.DEFAULT_UPDATE_SITE, UpdaterUtil.MAIN_URL, "", "", null, null, 0l);
+		mainSite.setOfficial(true);
+		return mainSite;
+	}
+
+	private static void addAvailableUpdateSites(List< UpdateSite > sites,
+			Collection< UpdateSite > availableSites)
+	{
+		for (final UpdateSite site : availableSites ) {
+			Integer index = findIndexByName(sites, site);
 			if (index == null) {
-				url2index.put(site.getURL(), sites.size());
 				sites.add(site);
 			} else {
-				final UpdateSite listed = sites.get(index.intValue());
-				site.setDescription(listed.getDescription());
-				site.setMaintainer(listed.getMaintainer());
-				sites.set(index.intValue(), site);
+				sites.set(index, site);
 			}
 		}
+	}
 
-		// make sure names are unique
+	private static ArrayList< URLChange > mergeLocalAndAvailabelUpdateSites(FilesCollection files,
+			List< UpdateSite > sites)
+	{
+		ArrayList< URLChange > urlChanges = new ArrayList<>();
+		for (final UpdateSite local : files.getUpdateSites(true)) {
+			Integer index = findIndexByName(sites, local);
+			if (index == null) {
+				sites.add(local);
+				Optional< URLChange > change = URLChange.create(local,
+						HTTPSUtil.fixImageJUserSiteProtocol(local.getURL()));
+				change.ifPresent( urlChanges::add );
+			} else {
+				final UpdateSite available = sites.get(index);
+				local.setOfficial(available.isOfficial());
+				local.setDescription(available.getDescription());
+				local.setMaintainer(available.getMaintainer());
+				Optional< URLChange > change =
+						URLChange.create(local, available.getURL());
+				change.ifPresent( urlChanges::add );
+				sites.set(index, local);
+			}
+		}
+		return urlChanges;
+	}
+
+	private static Integer findIndexByName(List<UpdateSite> sites, UpdateSite site) {
+		for (int i = 0; i < sites.size(); i++) {
+			if( sites.get(i).getName().equals(site.getName()) )
+				return i;
+		}
+		return null;
+	}
+
+	private static void makeSureNamesAreUnique(List< UpdateSite > sites)
+	{
+		final Set<String> names = new HashSet<>();
 		for (final UpdateSite site : sites) {
 			if (site.isActive()) continue;
 			if (names.contains(site.getName())) {
@@ -198,8 +233,6 @@ public final class AvailableSites {
 			}
 			names.add(site.getName());
 		}
-
-		return sites;
 	}
 
 	/**
@@ -207,18 +240,7 @@ public final class AvailableSites {
 	 * <em>and</em> adds them to the given {@link FilesCollection}.
 	 */
 	public static void initializeAndAddSites(final FilesCollection files) {
-		initializeAndAddSites(files, null);
-	}
-
-	/**
-	 * As {@link #initializeAndAddSites(FilesCollection)} with an optional
-	 * {@link LogService} for reporting errors.
-	 */
-	public static void initializeAndAddSites(final FilesCollection files, final LogService log) {
-		for (final UpdateSite site : initializeSites(files, log)) {
-			files.addUpdateSite(site);
-		}
-
+		initializeAndAddSites(files, (Logger) null);
 	}
 
 	private static String stripWikiMarkup(final String[] columns, int index) {
@@ -227,4 +249,42 @@ public final class AvailableSites {
 		return string.replaceAll("'''", "").replaceAll("\\[\\[([^\\|\\]]*\\|)?([^\\]]*)\\]\\]", "$2").replaceAll("\\[[^\\[][^ ]*([^\\]]*)\\]", "$1");
 	}
 
+	/**
+	 * Checks whether for all update sites of a given {@link FilesCollection} there is
+	 * an updated URL on the remote list of available update sites.
+	 */
+	public static boolean hasUpdateSiteURLUpdates(FilesCollection plugins) throws IOException {
+		return hasUpdateSiteURLUpdates(plugins, getAvailableSites());
+	}
+
+	/**
+	 * Checks whether for all update sites of a given {@link FilesCollection} there is
+	 * an updated URL on the given list of available sites.
+	 */
+	public static boolean hasUpdateSiteURLUpdates(FilesCollection plugins, Map<String, UpdateSite> availableSites) {
+		for(UpdateSite site : availableSites.values()) {
+			// TODO use site id
+			UpdateSite local = plugins.getUpdateSite(site.getName(), false);
+			if(local == null) continue;
+			if(!local.shouldKeepURL() && !local.getURL().equals(site.getURL())) {
+				return true;
+			}
+		}
+		if(HTTPSUtil.hasImageJUserSiteProtocolUpdates(plugins)) return true;
+		return false;
+	}
+
+	/**
+	 * Apply prepared changes to update site URLs
+	 */
+	public static void applySitesURLUpdates(FilesCollection plugins, List< URLChange > urlChanges ) {
+		for(URLChange site : urlChanges) {
+			site.applyIfApproved();
+		}
+		try {
+			plugins.write();
+		} catch (IOException | SAXException | TransformerConfigurationException e) {
+			e.printStackTrace();
+		}
+	}
 }

--- a/src/main/java/net/imagej/updater/util/HTTPSUtil.java
+++ b/src/main/java/net/imagej/updater/util/HTTPSUtil.java
@@ -1,0 +1,68 @@
+package net.imagej.updater.util;
+
+import org.scijava.log.LogService;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+public class HTTPSUtil {
+
+	private static boolean secureMode = true;
+
+	private static final String secureURL = "https://imagej.net/api.php";
+	private static final String insecureUserSiteURL = "http://sites.imagej.net";
+	private static final String secureUserSiteURL = "https://sites.imagej.net";
+
+	/**
+	 * Calls {@link #secureURL} to check whether the HTTPS certificate can be handled by the JVM.
+	 */
+	public static void checkHTTPSSupport(LogService log) {
+		HttpURLConnection connection = null;
+		try {
+			connection = (HttpURLConnection) new URL(secureURL).openConnection();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		try {
+			connection.setRequestMethod("HEAD");
+			connection.setConnectTimeout(10000);
+		} catch (ProtocolException e) {
+			e.printStackTrace();
+		}
+		try {
+			connection.getResponseCode();
+			secureMode = true;
+		} catch (UnknownHostException e) {
+			String msg = "Could not determine the IP address of https://imagej.net. "
+					+ "Make sure you are connected to a network.";
+			if (log != null) log.warn(msg);
+			else System.out.println("[WARNING] " + msg);
+		} catch (SSLHandshakeException e) {
+			secureMode = false;
+			String msg = "Your Java might be too old to handle updates via HTTPS. This is a security risk. " +
+					"Depending on your setup please download a recent version of this software or update your local Java installation.";
+			if (log != null) log.warn(msg);
+			else System.out.println("[WARNING] " + msg);
+		} catch (SocketTimeoutException e) {
+			secureMode = false;
+			String msg = "Timeout while trying to update securely via HTTPS. Will fall back to HTTP. This is a security risk. " +
+					"Please contact your system administrator to enable communication via HTTPS.";
+			if (log != null) log.warn(msg);
+			else System.out.println("[WARNING] " + msg);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * @return the protocol component of the URL depending on whether this ImageJ instance can handle HTTPS
+	 */
+	public static String getProtocol() {
+		return secureMode ? "https://" : "http://";
+	}
+}

--- a/src/main/java/net/imagej/updater/util/UpdaterUtil.java
+++ b/src/main/java/net/imagej/updater/util/UpdaterUtil.java
@@ -84,7 +84,7 @@ import org.scijava.log.StderrLogService;
  */
 public class UpdaterUtil {
 
-	public static String MAIN_URL = "http://update.imagej.net/";
+	public static String MAIN_URL = HTTPSUtil.getProtocol() + "update.imagej.net/";
 	public static String UPDATE_DIRECTORY = "/home/imagej/update-site";
 	public static String SSH_HOST = "update.imagej.net";
 

--- a/src/test/java/net/imagej/updater/AbstractUploaderTestBase.java
+++ b/src/test/java/net/imagej/updater/AbstractUploaderTestBase.java
@@ -31,12 +31,10 @@
 
 package net.imagej.updater;
 
-import static net.imagej.updater.UpdaterTestUtils.cleanup;
-import static net.imagej.updater.UpdaterTestUtils.initialize;
-import static net.imagej.updater.UpdaterTestUtils.writeFile;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNotNull;
+import net.imagej.updater.util.StderrProgress;
+import net.imagej.updater.util.UpdaterUtil;
+import org.apache.commons.lang.NotImplementedException;
+import org.junit.After;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,11 +42,10 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import net.imagej.updater.FilesCollection;
-import net.imagej.updater.util.StderrProgress;
-import net.imagej.updater.util.UpdaterUtil;
-
-import org.junit.After;
+import static net.imagej.updater.UpdaterTestUtils.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
 
 /**
  * An abstract base class for testing uploader backends.
@@ -87,6 +84,8 @@ public abstract class AbstractUploaderTestBase {
 			assertTrue(deleter.login());
 			deleter.delete(UpdaterUtil.XML_COMPRESSED);
 			deleter.delete("plugins/");
+			assertTrue(deleter.isDeleted(UpdaterUtil.XML_COMPRESSED));
+			assertTrue(deleter.isDeleted("plugins/"));
 			deleter.logout();
 		}
 
@@ -144,8 +143,11 @@ public abstract class AbstractUploaderTestBase {
 	}
 
 	public interface Deleter {
-		public abstract boolean login();
-		public abstract void delete(final String path) throws IOException;
-		public abstract void logout();
+		boolean login();
+		void delete(final String path) throws IOException;
+		void logout();
+		default boolean isDeleted(String path) throws IOException {
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/test/java/net/imagej/updater/UpdaterTest.java
+++ b/src/test/java/net/imagej/updater/UpdaterTest.java
@@ -31,28 +31,17 @@
 
 package net.imagej.updater;
 
-import static net.imagej.updater.UpdaterTestUtils.addUpdateSite;
-import static net.imagej.updater.UpdaterTestUtils.assertAction;
-import static net.imagej.updater.UpdaterTestUtils.assertCount;
-import static net.imagej.updater.UpdaterTestUtils.assertNotEqual;
-import static net.imagej.updater.UpdaterTestUtils.assertStatus;
-import static net.imagej.updater.UpdaterTestUtils.cleanup;
-import static net.imagej.updater.UpdaterTestUtils.getWebRoot;
-import static net.imagej.updater.UpdaterTestUtils.initDb;
-import static net.imagej.updater.UpdaterTestUtils.initialize;
-import static net.imagej.updater.UpdaterTestUtils.makeIJRoot;
-import static net.imagej.updater.UpdaterTestUtils.makeList;
-import static net.imagej.updater.UpdaterTestUtils.progress;
-import static net.imagej.updater.UpdaterTestUtils.readDb;
-import static net.imagej.updater.UpdaterTestUtils.readGzippedStream;
-import static net.imagej.updater.UpdaterTestUtils.touch;
-import static net.imagej.updater.UpdaterTestUtils.update;
-import static net.imagej.updater.UpdaterTestUtils.upload;
-import static net.imagej.updater.UpdaterTestUtils.writeFile;
-import static net.imagej.updater.UpdaterTestUtils.writeGZippedFile;
-import static net.imagej.updater.UpdaterTestUtils.writeJar;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertNotEquals;
+import net.imagej.updater.Conflicts.Conflict;
+import net.imagej.updater.Conflicts.Resolution;
+import net.imagej.updater.FileObject.Action;
+import net.imagej.updater.FileObject.Status;
+import net.imagej.updater.test.Dependencee;
+import net.imagej.updater.test.Dependency;
+import net.imagej.updater.util.UpdaterUtil;
+import org.junit.After;
+import org.junit.Test;
+import org.scijava.test.TestUtils;
+import org.scijava.util.FileUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -63,26 +52,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
 
-import net.imagej.updater.Checksummer;
-import net.imagej.updater.Conflicts;
-import net.imagej.updater.FileObject;
-import net.imagej.updater.FilesCollection;
-import net.imagej.updater.Installer;
-import net.imagej.updater.XMLFileDownloader;
-import net.imagej.updater.XMLFileReader;
-import net.imagej.updater.XMLFileWriter;
-import net.imagej.updater.Conflicts.Conflict;
-import net.imagej.updater.Conflicts.Resolution;
-import net.imagej.updater.FileObject.Action;
-import net.imagej.updater.FileObject.Status;
-import net.imagej.updater.test.Dependencee;
-import net.imagej.updater.test.Dependency;
-import net.imagej.updater.util.UpdaterUtil;
-
-import org.junit.After;
-import org.junit.Test;
-import org.scijava.test.TestUtils;
-import org.scijava.util.FileUtils;
+import static net.imagej.updater.UpdaterTestUtils.*;
+import static org.junit.Assert.*;
 
 /**
  * Tests various classes of the {@link net.imagej.updater} package and
@@ -711,6 +682,8 @@ public class UpdaterTest {
 		assertStatus(Status.MODIFIED, files.get("jars/hello.jar"));
 
 		FileUtils.deleteRecursively(webRoot2);
+
+		cleanup(files2);
 	}
 
 	@Test
@@ -1308,6 +1281,7 @@ public class UpdaterTest {
 		assertStatus(Status.OBSOLETE_UNINSTALLED, files.get("jars/something-cool.jar"));
 		FileUtils.deleteRecursively(ijRoot2);
 		FileUtils.deleteRecursively(webRoot2);
+
 	}
 
 	@Test

--- a/src/test/java/net/imagej/updater/UpdaterTestUtils.java
+++ b/src/test/java/net/imagej/updater/UpdaterTestUtils.java
@@ -314,7 +314,7 @@ public class UpdaterTestUtils {
 		final UpdateSite updateSite = files.getUpdateSite(FilesCollection.DEFAULT_UPDATE_SITE, false);
 		assertNotNull(updateSite);
 
-		updateSite.setURL( webRoot.toURI().toURL().toString());
+		updateSite.setURL(webRoot.toURI().toURL().toString());
 		updateSite.setHost("file:localhost");
 		updateSite.setUploadDirectory(webRoot.getAbsolutePath());
 	}

--- a/src/test/java/net/imagej/updater/util/AvailableSitesTest.java
+++ b/src/test/java/net/imagej/updater/util/AvailableSitesTest.java
@@ -1,0 +1,301 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2019 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.updater.util;
+
+import net.imagej.updater.URLChange;
+import net.imagej.updater.FilesCollection;
+import net.imagej.updater.UpdateSite;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static junit.framework.TestCase.assertTrue;
+import static net.imagej.updater.UpdaterTestUtils.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Tests functionalities related to the available update sites,
+ * including HTTPS compatibility
+ *
+ * @author Deborah Schmidt
+ */
+public class AvailableSitesTest {
+
+	@Test
+	public void testSecureMode() throws IOException {
+		// check if HTTPS is supported
+		HTTPSUtil.checkHTTPSSupport(null);
+		boolean secure = HTTPSUtil.supportsHTTPS();
+
+		// get list of available sites
+		Map<String, UpdateSite > availableUpdateSites = AvailableSites.getAvailableSites();
+
+		// test whether the main ImageJ update site is using HTTP or HTTPS
+		UpdateSite mainUpdateSite = null;
+		for(UpdateSite site : availableUpdateSites.values()) {
+			if(site.getName().equals("ImageJ")) {
+				mainUpdateSite = site;
+				break;
+			}
+		}
+		assertNotNull(mainUpdateSite);
+		assertEquals(mainUpdateSite.getURL(), secure? "https://update.imagej.net/" : "http://update.imagej.net/");
+	}
+
+	@Test
+	public void testAvailableUpdateSites() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+
+		// add two official update sites
+		applyOfficialUpdateSitesList(files, "a", "http://a.de/", "b", "http://b.de/");
+
+		// restart
+		files = readFromDb(files);
+
+		// test if update site URLS match
+		assertEquals("http://a.de/", files.getUpdateSite("a", true).getURL());
+		assertEquals("http://b.de/", files.getUpdateSite("b", true).getURL());
+
+		cleanup(files);
+
+	}
+
+	@Test
+	public void testAvailableUpdateSitesChange() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+
+		// add two official update sites
+		applyOfficialUpdateSitesList(files, "a", "http://a.de/", "b", "http://b.de/");
+
+		// apply changes to the list of available update sites
+		applyOfficialUpdateSitesList(files, "a", "http://newa.de/", "b", "http://newb.de/");
+
+		// restart
+		files = readFromDb(files);
+
+		// test if the update site URLs got updated
+		assertEquals("http://newa.de/", files.getUpdateSite("a", true).getURL());
+		assertEquals("http://newb.de/", files.getUpdateSite("b", true).getURL());
+
+		cleanup(files);
+
+	}
+
+	@Test
+	public void testLocalUpdateSiteURLModification() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+
+		// add two official update sites
+		applyOfficialUpdateSitesList(files, "a", "http://a.de/", "b", "http://b.de/");
+
+		// set the URL of one update site and remember choice
+		UpdateSite b = files.getUpdateSite("b", true);
+		b.setURL("http://manuallymodified.de/");
+		b.setKeepURL(true);
+
+		// write and read the changes (= restart)
+		files.write();
+		files = readFromDb(files);
+
+		// test whether the manually modified URL is returned by default
+		assertEquals("http://manuallymodified.de/", files.getUpdateSite("b", true).getURL());
+
+		// restart
+		files = readFromDb(files);
+
+		// apply changes to the URLs on the list of available update sites
+		applyOfficialUpdateSitesList(files, "a", "http://newa.de/", "b", "http://newb.de/");
+
+		// test whether the update site URLs got updated
+		assertEquals("http://newa.de/", files.getUpdateSite("a", true).getURL());
+		// test whether the manually modified update site URL was kept
+		assertEquals("http://manuallymodified.de/", files.getUpdateSite("b", true).getURL());
+
+		cleanup(files);
+
+	}
+
+	@Test
+	public void testAutomaticSecureUpgrade() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+
+		// skip test if HTTPS is not supported
+		HTTPSUtil.checkHTTPSSupport(null);
+		assumeTrue(HTTPSUtil.supportsHTTPS());
+
+		// add two official update sites
+		applyOfficialUpdateSitesList(files, "a", "http://sites.imagej.net/a/", "b", "http://other.server.net/b/");
+
+		// test whether the HTTPS URL is used for sites on imagej.net
+		assertEquals("https://sites.imagej.net/a/", files.getUpdateSite("a", true).getURL());
+		assertEquals("http://other.server.net/b/", files.getUpdateSite("b", true).getURL());
+
+		cleanup(files);
+	}
+
+	@Test
+	public void testMirrorMainUpdateSite() throws Exception {
+
+		String mirrorURL = "https://downloads.micron.ox.ac.uk/fiji_update/mirrors/imagej/";
+
+		// load initial files collection
+		FilesCollection files = initialize();
+
+		// skip test if HTTPS is not supported
+		HTTPSUtil.checkHTTPSSupport(null);
+		assumeTrue(HTTPSUtil.supportsHTTPS());
+
+		// apply mirror URL as source for main update site
+		applyOfficialUpdateSitesList(files, "ImageJ", mirrorURL);
+
+		// test whether the mirror URL is in use
+		assertEquals(mirrorURL, files.getUpdateSite("ImageJ", true).getURL());
+
+		// write and read the changes (= restart)
+		files.write();
+		files = readFromDb(files);
+
+		// apply list of available update sites containing default ImageJ URL
+		applyOfficialUpdateSitesList(files, "Image", "https://update.imagej.net/");
+
+		// restart
+		files = readFromDb(files);
+
+		// test whether the mirror URL is still in use
+		assertEquals(mirrorURL, files.getUpdateSite("ImageJ", true).getURL());
+
+		cleanup(files);
+
+	}
+
+	@Test
+	public void testOfficialFlag() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+
+		// get list of available update sites
+		AvailableSites.initializeAndAddSites(files);
+
+		// test whether the update sites are marked as official
+		files.getUpdateSites(true).forEach(updateSite -> assertTrue(updateSite.isOfficial()));
+
+		// write and read the changes (= restart)
+		files.write();
+		files = readFromDb(files);
+
+		// test whether the update sites are still marked as official
+		files.getUpdateSites(true).forEach(updateSite -> assertTrue(updateSite.isOfficial()));
+
+		cleanup(files);
+	}
+
+	@Test
+	public void testActiveUpdateSitesChange() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+
+		// add two official update sites
+		applyOfficialUpdateSitesList(files, "a", "http://a.de/");
+
+		files.getUpdateSite("a", true).setActive(true);
+
+		// apply changes to the list of available update sites
+		applyOfficialUpdateSitesList(files, "a", "http://newa.de/");
+
+		// restart
+		files = readFromDb(files);
+
+		// test if the update site URLs got updated
+		assertEquals("http://newa.de/", files.getUpdateSite("a", true).getURL());
+
+		cleanup(files);
+
+	}
+	@Test
+	public void testURLFormattingChange() {
+		UpdateSite updateSite = createOfficialSite("ImageJ", "https://sites.imagej.net/ImageJ/");
+		Optional< URLChange > change =
+				URLChange.create(updateSite, "https://sites.imagej.net/ImageJ");
+		assertFalse(change.isPresent());
+	}
+
+	protected static FilesCollection readFromDb(final FilesCollection ijRoot) {
+		FilesCollection files = new FilesCollection(ijRoot.prefix(""));
+		try {
+			files.read();
+		} catch (IOException | ParserConfigurationException | SAXException e) {
+			e.printStackTrace();
+		}
+		return files;
+	}
+
+	private void applyOfficialUpdateSitesList(FilesCollection files, String... args) {
+		List< UpdateSite > availableSites = asListOfUpdateSites(args);
+		List< URLChange > urlChanges = AvailableSites
+				.initializeAndAddSites(files, availableSites);
+		urlChanges.forEach(change -> change.setApproved(change.isRecommended()));
+		AvailableSites.applySitesURLUpdates(files, urlChanges);
+	}
+
+	private List< UpdateSite > asListOfUpdateSites(String[] args) {
+		assert(args.length % 2 == 0);
+		List<UpdateSite> availableUpdateSites = new ArrayList<>();
+		for (int i = 0; i < args.length-1; i+=2) {
+			availableUpdateSites.add(createOfficialSite(args[i], args[i+1]));
+		}
+		return availableUpdateSites;
+	}
+
+	private UpdateSite createOfficialSite(String name, String url) {
+		UpdateSite site = new UpdateSite(name, url, "", "", "", "", 0);
+		site.setOfficial(true);
+		site.setHost("file:localhost");
+		return site;
+	}
+}

--- a/src/test/java/net/imagej/updater/util/AvailableSitesTest.java
+++ b/src/test/java/net/imagej/updater/util/AvailableSitesTest.java
@@ -257,6 +257,61 @@ public class AvailableSitesTest {
 		cleanup(files);
 
 	}
+
+	@Test
+	public void testCommandLineRefreshUpdateSites() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+		// there should be a main update site
+		UpdateSite updateSite = files.getUpdateSite("ImageJ", true);
+		updateSite.setActive(true);
+		// the main update site should point to a local folder
+		String oldLocalUrl = files.getUpdateSite("ImageJ", true).getURL();
+
+		// when simulating refreshing the update sites, we can observe the changes
+		System.out.println("ImageJ --update refresh-update-sites --simulate");
+		files = main(files, "refresh-update-sites", "--simulate");
+		// the main update site URL should still be the same
+		assertEquals(oldLocalUrl, files.getUpdateSite("ImageJ", true).getURL());
+
+		// refresh the URLs again, now forcing to update all URLs
+		System.out.println("ImageJ --update refresh-update-sites --updateall");
+		files = main(files, "refresh-update-sites", "--updateall");
+		// the main update site should now point to the imagej.net server
+		assertNotEquals(oldLocalUrl, files.getUpdateSite("ImageJ", true).getURL());
+		assertFalse(files.getUpdateSite("ImageJ", true).shouldKeepURL());
+
+		cleanup(files);
+	}
+
+	@Test
+	public void testCommandLineRefreshInactiveUpdateSites() throws Exception {
+
+		// load initial files collection
+		FilesCollection files = initialize();
+		// there should be a main update site
+		UpdateSite updateSite = files.getUpdateSite("ImageJ", true);
+		updateSite.setActive(false);
+		// the main update site should point to a local folder
+		String oldLocalUrl = files.getUpdateSite("ImageJ", true).getURL();
+
+		// when simulating refreshing the update sites, we can observe the changes
+		System.out.println("ImageJ --update refresh-update-sites --simulate");
+		files = main(files, "refresh-update-sites", "--simulate");
+		// the main update site URL should still be the same
+		assertEquals(oldLocalUrl, files.getUpdateSite("ImageJ", true).getURL());
+
+		// refresh the URLs again, now forcing to update all URLs
+		System.out.println("ImageJ --update refresh-update-sites");
+		files = main(files, "refresh-update-sites");
+		// the main update site should now point to the imagej.net server
+		assertNotEquals(oldLocalUrl, files.getUpdateSite("ImageJ", true).getURL());
+		assertFalse(files.getUpdateSite("ImageJ", true).shouldKeepURL());
+
+		cleanup(files);
+	}
+
 	@Test
 	public void testURLFormattingChange() {
 		UpdateSite updateSite = createOfficialSite("ImageJ", "https://sites.imagej.net/ImageJ/");


### PR DESCRIPTION
See #70. This is the PR for V1.

What's changed:
- check HTTPS certificate
- handle `SocketTimeoutException` -> warning and fallback to HTTP
- handle `SSLHandshakeException` -> warning and fallback to HTTP 
- `UnknownHostException` -> warning that internet is down

- local URLs of available update sites will be updated if the remote list changed  (#66)

This is a two step process:
```Java
// check HTTPS support
ProtocolUtil.checkHTTPSSupport(log);
// convert URLs from imagej.net to HTTPS or HTTP, depending on what's supported
AvailableSites.fixUserSitesProtocol(files); 
// download list of available update sites and merge with existing update sites
AvailableSites.initializeAndAddSites(files, log);
```
Then the user interface can notify the user of changes to activated update site URLs and ask for approval. Afterwards, changes to the URLs will be saved with this line:
```Java
AvailableSites.applySitesURLUpdates(files);
```

Consequences for users:
- if our certificate is supported, their update site links should be updated to HTTPS
- any URLs that were manually changed in the past will be reset to the remote URLs
- future manual changes will be saved and not overridden
- there is a test for mirrors (it currently only matches if the URL starts with `https://downloads.micron.ox.ac.uk` and does not recommend updating the the official links in this case) @carandraug

Open questions:
- the scripts also contain HTTP links, not sure how relevant they are