### PR TITLE
Add deletion check to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,5 +141,10 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/test/java/net/imagej/updater/AbstractUploaderTestBase.java
+++ b/src/test/java/net/imagej/updater/AbstractUploaderTestBase.java
@@ -31,12 +31,10 @@
 
 package net.imagej.updater;
 
-import static net.imagej.updater.UpdaterTestUtils.cleanup;
-import static net.imagej.updater.UpdaterTestUtils.initialize;
-import static net.imagej.updater.UpdaterTestUtils.writeFile;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNotNull;
+import net.imagej.updater.util.StderrProgress;
+import net.imagej.updater.util.UpdaterUtil;
+import org.apache.commons.lang.NotImplementedException;
+import org.junit.After;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,11 +42,10 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import net.imagej.updater.FilesCollection;
-import net.imagej.updater.util.StderrProgress;
-import net.imagej.updater.util.UpdaterUtil;
-
-import org.junit.After;
+import static net.imagej.updater.UpdaterTestUtils.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
 
 /**
  * An abstract base class for testing uploader backends.
@@ -87,6 +84,8 @@ public abstract class AbstractUploaderTestBase {
 			assertTrue(deleter.login());
 			deleter.delete(UpdaterUtil.XML_COMPRESSED);
 			deleter.delete("plugins/");
+			assertTrue(deleter.isDeleted(UpdaterUtil.XML_COMPRESSED));
+			assertTrue(deleter.isDeleted("plugins/"));
 			deleter.logout();
 		}
 
@@ -144,8 +143,11 @@ public abstract class AbstractUploaderTestBase {
 	}
 
 	public interface Deleter {
-		public abstract boolean login();
-		public abstract void delete(final String path) throws IOException;
-		public abstract void logout();
+		boolean login();
+		void delete(final String path) throws IOException;
+		void logout();
+		default boolean isDeleted(String path) throws IOException {
+			throw new NotImplementedException();
+		}
 	}
 }


### PR DESCRIPTION
The current test for uploading is pretending things are working when they are not.

The current webdav uploader has a reflection hack overriding the default GET method of a HTTP request by special ones like `DELETE` or `OPTIONS`. For HTTPS, this hack does not work. Therefore, when assuming the DELETE method is called, the GET method is called instead. In case the file is present, it returns `200` - all good. The test is assuming deleting worked and continues..

This PR adds a test if deleted files really don't exist anymore afterwards. It also adds a `boolean isDeleted(String path)` function to Deleter interface. Other Uploaders must implement this method, otherwise `NotImplementedException` is thrown when running this test. The Exception is the reason why I added the `commons-lang` dependency.. 

Not happy with the naming of `isUpdateSiteEmpty()` either since the test is only checking if the `db.xml.gz` is present.. But since it's a public method I was not sure about renaming it.