### PR TITLE
Fix update site order and add test for ordering

### DIFF
--- a/src/main/java/net/imagej/updater/FilesCollection.java
+++ b/src/main/java/net/imagej/updater/FilesCollection.java
@@ -63,8 +63,12 @@ import net.imagej.updater.action.KeepAsIs;
 import net.imagej.updater.action.Remove;
 import net.imagej.updater.action.Uninstall;
 import net.imagej.updater.action.Upload;
-import net.imagej.updater.util.*;
 
+import net.imagej.updater.util.DependencyAnalyzer;
+import net.imagej.updater.util.HTTPSUtil;
+import net.imagej.updater.util.Progress;
+import net.imagej.updater.util.UpdateCanceledException;
+import net.imagej.updater.util.UpdaterUtil;
 import org.scijava.log.LogService;
 import org.xml.sax.SAXException;
 
@@ -170,6 +174,11 @@ public class FilesCollection extends LinkedHashMap<String, FileObject>
 		for (final Map.Entry<String, UpdateSite> entry : updateSites.entrySet()) {
 			entry.getValue().rank = counter++;
 		}
+	}
+
+	public void replaceUpdateSites(List<UpdateSite> sites) {
+		updateSites.clear();
+		sites.forEach(site -> addUpdateSite(site));
 	}
 
 	/** @deprecated use {@link #getUpdateSite(String, boolean)} instead */

--- a/src/main/java/net/imagej/updater/util/AvailableSites.java
+++ b/src/main/java/net/imagej/updater/util/AvailableSites.java
@@ -40,7 +40,16 @@ import org.scijava.log.Logger;
 import org.xml.sax.SAXException;
 import javax.xml.transform.TransformerConfigurationException;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Utility class for parsing the list of available update sites.
@@ -143,9 +152,9 @@ public final class AvailableSites {
 		ArrayList< URLChange > urlChanges = mergeLocalAndAvailabelUpdateSites(
 				files, sites);
 		makeSureNamesAreUnique(sites);
-		for (final UpdateSite site : sites) {
-			files.addUpdateSite(site);
-		}
+
+		files.replaceUpdateSites(sites);
+
 		return urlChanges;
 	}
 

--- a/src/main/java/net/imagej/updater/util/AvailableSites.java
+++ b/src/main/java/net/imagej/updater/util/AvailableSites.java
@@ -149,7 +149,7 @@ public final class AvailableSites {
 	{
 		final List< UpdateSite > sites = prepareAvailableUpdateSites(availableSites);
 		// method is package private to allow testing
-		ArrayList< URLChange > urlChanges = mergeLocalAndAvailabelUpdateSites(
+		ArrayList< URLChange > urlChanges = mergeLocalAndAvailableUpdateSites(
 				files, sites);
 		makeSureNamesAreUnique(sites);
 
@@ -201,8 +201,8 @@ public final class AvailableSites {
 		}
 	}
 
-	private static ArrayList< URLChange > mergeLocalAndAvailabelUpdateSites(FilesCollection files,
-			List< UpdateSite > sites)
+	private static ArrayList< URLChange > mergeLocalAndAvailableUpdateSites(FilesCollection files,
+	                                                                        List< UpdateSite > sites)
 	{
 		ArrayList< URLChange > urlChanges = new ArrayList<>();
 		for (final UpdateSite local : files.getUpdateSites(true)) {


### PR DESCRIPTION
The latest changes to the updater introduced the problem that newly added official update sites would appear below personal update sites in the updater list. This PR makes sure to put personal update sites at the end of the list of update sites.