### PR TITLE
Prevent pointless server connections in headless mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/net/imagej/updater/DefaultUpdateService.java
+++ b/src/main/java/net/imagej/updater/DefaultUpdateService.java
@@ -62,6 +62,7 @@ public class DefaultUpdateService extends AbstractService implements
 	UpdateService
 {
 
+	private static final String DISABLE_AUTOCHECK_PROPERTY = "imagej.updater.disableAutocheck";
 	private static final String LAST_SOFT_CHECK_KEY = "lastSoftCheck";
 	private static final long TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
@@ -112,6 +113,7 @@ public class DefaultUpdateService extends AbstractService implements
 	@EventHandler
 	protected void onEvent(final UIShownEvent evt) {
 		if (evt.getUI() instanceof HeadlessUI) return;
+		if (Boolean.getBoolean(DISABLE_AUTOCHECK_PROPERTY)) return;
 
 		// Auto-check only once every 24 hours.
 		final long now = System.currentTimeMillis();

--- a/src/main/java/net/imagej/updater/DefaultUpdateService.java
+++ b/src/main/java/net/imagej/updater/DefaultUpdateService.java
@@ -37,14 +37,15 @@ import java.io.IOException;
 import javax.xml.parsers.ParserConfigurationException;
 
 import net.imagej.updater.util.AvailableSites;
-
 import net.imagej.updater.util.HTTPSUtil;
+
 import org.scijava.app.AppService;
 import org.scijava.command.CommandService;
 import org.scijava.event.EventHandler;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.prefs.PrefService;
 import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
 import org.scijava.ui.event.UIShownEvent;
@@ -61,11 +62,17 @@ public class DefaultUpdateService extends AbstractService implements
 	UpdateService
 {
 
+	private static final String LAST_SOFT_CHECK_KEY = "lastSoftCheck";
+	private static final long TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+
 	@Parameter
 	private CommandService commandService;
 
 	@Parameter
 	private AppService appService;
+
+	@Parameter
+	private PrefService prefService;
 
 	@Parameter(required = false)
 	private LogService log;
@@ -105,6 +112,12 @@ public class DefaultUpdateService extends AbstractService implements
 	@EventHandler
 	protected void onEvent(final UIShownEvent evt) {
 		if (evt.getUI() instanceof HeadlessUI) return;
+
+		// Auto-check only once every 24 hours.
+		final long now = System.currentTimeMillis();
+		final long lastSoftCheck = prefService.getLong(getClass(), LAST_SOFT_CHECK_KEY, 0);
+		if (now < lastSoftCheck + TWENTY_FOUR_HOURS) return;
+		prefService.put(getClass(), LAST_SOFT_CHECK_KEY, now);
 
 		// NB: Check for updates, but on a separate thread (not the EDT!).
 		commandService.run(CheckForUpdates.class, true);

--- a/src/main/java/net/imagej/updater/DefaultUpdateService.java
+++ b/src/main/java/net/imagej/updater/DefaultUpdateService.java
@@ -48,6 +48,7 @@ import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
 import org.scijava.ui.event.UIShownEvent;
+import org.scijava.ui.headless.HeadlessUI;
 import org.xml.sax.SAXException;
 
 /**
@@ -103,6 +104,8 @@ public class DefaultUpdateService extends AbstractService implements
 	 */
 	@EventHandler
 	protected void onEvent(final UIShownEvent evt) {
+		if (evt.getUI() instanceof HeadlessUI) return;
+
 		// NB: Check for updates, but on a separate thread (not the EDT!).
 		commandService.run(CheckForUpdates.class, true);
 	}


### PR DESCRIPTION
We have to investigate how to deal with the updater routine in headless mode. As far as I know, headless updating is executed via the `CommandLine` class. Therefore it might be best to just stop the usual update check in headless mode. This is implemented in this PR and still needs to be tested.