### PR TITLE
bootstrap.js: update to HTTPS, add Java-8 update site

### DIFF
--- a/bin/bootstrap.js
+++ b/bin/bootstrap.js
@@ -26,15 +26,13 @@ importClass(Packages.java.net.URL);
 importClass(Packages.java.net.URLClassLoader);
 importClass(Packages.java.util.regex.Pattern);
 
-baseURL = 'http://update.imagej.net/jars/';
+baseURL = 'https://sites.imagej.net/Java-8/jars/';
 jars = [
-	'imagej-ui-swing-0.11.2.jar-20150501184913',
-	'imagej-plugins-uploader-webdav-0.2.0.jar-20141219193933',
-	'imagej-updater-0.7.5.jar-20150522102918',
-	'scijava-common-2.44.2.jar-20150720161756',
-	'imagej-common-0.14.0.jar-20150415222444',
-	'eventbus-1.4.jar-20120404210913',
-	'gentyref-1.1.0.jar-20140516211031'
+	'imagej-ui-swing-0.23.1.jar-20190813144239',
+	'imagej-plugins-uploader-webdav-0.3.1.jar-20190813144239',
+	'imagej-updater-0.10.4.jar-20200225103842',
+	'scijava-common-2.80.1.jar-20191101144016',
+	'imagej-common-0.28.2.jar-20190516211613'
 ];
 
 isCommandLine = typeof arguments != 'undefined';
@@ -210,7 +208,8 @@ if (!new File(imagejDir, "db.xml.gz").exists()) {
 	files.getUpdateSite("ImageJ").timestamp = -1;
 	if (!"true".equalsIgnoreCase(System.getProperty("skip.fiji"))) {
 		IJ.showStatus("adding the Fiji update site");
-		files.addUpdateSite("Fiji", "http://update.fiji.sc/", null, null, -1);
+		files.addUpdateSite("Fiji", "https://update.fiji.sc/", null, null, -1);
+		files.addUpdateSite("Java-8", "https://sites.imagej.net/Java-8/", null, null, -1);
 	}
 	files.write();
 }


### PR DESCRIPTION
This PR updates the `bootstrap.js` script to HTTPS and adds the Java-8 update site since the HTTPS related updater JARs are also there.

I tested it by running the Fiji's `build.sh` script (without the deployment part) after replacing the link to [this bootstrapJ8.js script](https://downloads.imagej.net/bootstrapJ8.js) with the one from this PR, checking for no errors during the execution and then I started the Linux64 version which indeed used HTTPS links by default.

 I guess this script got manually copied to https://downloads.imagej.net/bootstrapJ8.js or is there another source for the `bootstrapJ8.js` script?

@ctrueden mentioned [here](https://github.com/imagej/imagej-updater/issues/83) that we might break someone's Java 6 installation - I'm not sure how since the bootstrapJ8.js script already created Fiji's with Java-8 enabled. Is this `bootstrap.js` script in this repository used for anything else?