### PR TITLE
Support the update of licenses collected in a directory licenses

### DIFF
--- a/src/main/java/net/imagej/updater/Checksummer.java
+++ b/src/main/java/net/imagej/updater/Checksummer.java
@@ -445,6 +445,7 @@ public class Checksummer extends AbstractProgressable {
 		{ "images" }, { ".png", ".tif", ".txt" },
 		{ "Contents" }, { ".icns", ".plist" },
 		{ "lib" }, { "" },
+		{ "licenses" }, { "" },
 		{ "mm" }, { "" },
 		{ "mmautofocus" }, { "" },
 		{ "mmplugins" }, { "" }


### PR DESCRIPTION
Add license to the updater paths without a file extension filter.

License files for all third party dependencies that have the necessary properties
set in their pom.xml can be generated with the license-maven-plugin:

mvn -Dlicense.organizeLicensesByDependencies=true license:download-licenses

other licenses should be added manually and then deposited in ImageJ's licenses
directory to be distributed by the updater.