### PR TITLE
extend error message with a link to the forum

### DIFF
--- a/src/main/java/net/imagej/updater/CheckForUpdates.java
+++ b/src/main/java/net/imagej/updater/CheckForUpdates.java
@@ -85,7 +85,8 @@ public class CheckForUpdates implements Command {
 					break;
 				case READ_ONLY:
 					final String message =
-						"Your ImageJ installation cannot be updated because it is read-only";
+						"Your ImageJ installation cannot be updated because it is read-only\n" +
+						"You can find potential solutions online https://forum.image.sc/t/warning-your-imagej-installation-cannot-be-updated-because-it-is-read-only/20333";
 					if (log != null) log.warn(message);
 					if (statusService != null) statusService.showStatus(message);
 					break;


### PR DESCRIPTION
Hi @frauzufall, @ctrueden,

I would like to add a link to the forum to an error message. We are repeatedly answering that question on the forum and I think it might help to have that short-cut directly in the error message.

Let me know what you think!

Cheers,
Robert