### PR TITLE
Add models folder

### DIFF
--- a/src/main/java/net/imagej/updater/Checksummer.java
+++ b/src/main/java/net/imagej/updater/Checksummer.java
@@ -441,6 +441,7 @@ public class Checksummer extends AbstractProgressable {
 		{ "plugins" }, { ".jar", ".class", ".txt", ".ijm", ".py", ".rb", ".clj", ".js", ".bsh", ".groovy", ".gvy" },
 		{ "scripts" }, { ".m",                     ".ijm", ".py", ".rb", ".clj", ".js", ".bsh", ".groovy", ".gvy" },
 		{ "macros" }, { ".txt", ".ijm" },
+		{ "models" }, { "" },
 		{ "luts" }, { ".lut" },
 		{ "images" }, { ".png", ".tif", ".txt" },
 		{ "Contents" }, { ".icns", ".plist" },


### PR DESCRIPTION
Adding a models  folder so developers can distribute domain-specific deep learning models developed for deepImageJ, StarDist or any future plugins that enable use of DL models in the ImageJ/FIJI environment. 
https://forum.image.sc/t/distributing-model-files-via-update-site/58223

I'm unsure what other changes need to be made. For example, the models folder is not there in ImageJ by default. 