### PR TITLE
Fix #106 by setting the correct update site flags in CommandLine.java

### DIFF
--- a/src/main/java/net/imagej/updater/CommandLine.java
+++ b/src/main/java/net/imagej/updater/CommandLine.java
@@ -1246,7 +1246,7 @@ public class CommandLine {
 			final String sshHost, final String uploadDirectory,
 			final boolean add) {
 		ensureChecksummed();
-		final UpdateSite site = files.getUpdateSite(name, true);
+		final UpdateSite site = files.getUpdateSite(name, false);
 		if (site == null || add) {
 			if (site != null)
 				throw die("Site '" + name + "' was already added!");
@@ -1273,7 +1273,7 @@ public class CommandLine {
 			final String url = urls.get(i);
 			final String sshHost = null;
 			final String uploadDirectory = null;
-			final UpdateSite site = files.getUpdateSite(name, true);
+			final UpdateSite site = files.getUpdateSite(name, false);
 			if (site != null)
 				throw die("Site '" + name + "' was already added!");
 			files.addUpdateSite(name, url, sshHost, uploadDirectory, 0l);


### PR DESCRIPTION
Note: to test this commit locally, I had to comment these to lines:

https://github.com/imagej/imagej-updater/blob/534083c2ea140337907a6d89e94ea1723875337c/src/main/java/net/imagej/updater/Conflicts.java#L189-L190

(Unrelated to this PR), I've also tested the option that [enables adding multiple update sites at once](https://github.com/imagej/imagej-updater/commit/20afd7297cf53a0f093f781f8c2d18e20ea2ccdf) and it worked:

```
./ImageJ-win64.exe --update add-update-sites "BAR" "https://sites.imagej.net/Tiago/" "IJPB-plugins" "https://sites.imagej.net/IJPB-plugins/"
```

I've updated the documentation accordingly (https://github.com/imagej/imagej.github.io/commit/d79a248950acc7514b6dc3cebead89e3f99f2e76)
